### PR TITLE
CacheManager.Debug is now used when HttpContextCacher and RedisCacher…

### DIFF
--- a/CacheSleeve.NET40/HttpContextCacher.cs
+++ b/CacheSleeve.NET40/HttpContextCacher.cs
@@ -17,7 +17,6 @@ namespace CacheSleeve
         {
             _cache = System.Web.HttpRuntime.Cache;
             _cacheSleeve = CacheManager.Settings;
-            _cacheSleeve.Debug = true;
         }
 
 

--- a/CacheSleeve.NET40/RedisCacher.cs
+++ b/CacheSleeve.NET40/RedisCacher.cs
@@ -17,8 +17,6 @@ namespace CacheSleeve
         public RedisCacher()
         {
             _cacheSleeve = CacheManager.Settings;
-            _cacheSleeve.Debug = true;
-
             _objectSerializer = new JsonObjectSerializer();
         }
 


### PR DESCRIPTION
… are initialized instead of setting true by default